### PR TITLE
Format Phone Number Upon Contact Creation

### DIFF
--- a/app/graphql/mutations/create_hifu.rb
+++ b/app/graphql/mutations/create_hifu.rb
@@ -22,7 +22,12 @@ module Mutations
         weightKG: graph_user.weightKG,
       )
 
-      user.contact = Contact.create(graph_user.contact.to_h)
+      contact = graph_user.contact.to_h
+      user.contact = Contact.create(
+        name: contact[:name],
+        email: contact[:email],
+        phone: "+1" + contact[:phone]
+      )
 
       user.route = Route.create(
         start_time: graph_user.route.startTime,
@@ -31,7 +36,7 @@ module Mutations
         party_size: graph_user.route.partySize,
         notes: graph_user.route.notes
       )
-      
+
       graph_user.route.waypoints.each_with_index do |waypoint, i|
         user.route.waypoints << Waypoint.create(
           latitude: waypoint.latitude,

--- a/spec/graphql/types/mutation_type_spec.rb
+++ b/spec/graphql/types/mutation_type_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Types::MutationType do
 
       expected_user = build(:user_route_contact)
       waypoints = build_list(:waypoint, 3)
-      
+      expected_user.contact.phone = "+15551234567"
+
       query = <<~QL
       mutation{
         createHifu(
@@ -31,7 +32,7 @@ RSpec.describe Types::MutationType do
           contact: {
             name: "#{expected_user.contact.name}"
             email: "#{expected_user.contact.email}"
-            phone: "#{expected_user.contact.phone}"
+            phone: "5551234567"
           }
           route: {
             startTime:  "#{expected_user.route.start_time}"
@@ -68,10 +69,11 @@ RSpec.describe Types::MutationType do
         }
       }
       QL
-      
+
       ql_response = HifuApiSchema.execute(query)
       user = User.first
-      
+
+
       expect(user.name).to eq(expected_user.name)
       expect(user.email).to eq(expected_user.email)
       expect(user.phone).to eq(expected_user.phone)
@@ -85,7 +87,7 @@ RSpec.describe Types::MutationType do
       expect(user.medical_conditions).to eq(expected_user.medical_conditions)
       expect(user.heightCM).to eq(expected_user.heightCM)
       expect(user.weightKG).to eq(expected_user.weightKG)
-      
+
       expect(user.contact.name).to eq(expected_user.contact.name)
       expect(user.contact.email).to eq(expected_user.contact.email)
       expect(user.contact.phone).to eq(expected_user.contact.phone)


### PR DESCRIPTION
# Merge to Master PR

#### Closes: #56 

- [x] All test passing, Test percentage: 99.12%
- [x] Runs in local dev environment
- [x] PR Documented, Ready for Review

## Type of change made

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test

### What's this PR do? (Detailed Description)

Updated the create_hifu mutation to add "+1" to the beginning of the contact number passed in from the FE.
Updated testing to reflect this -- had to overwrite contact phone number created by FactoryBot.

### Created (Classes, Methods, Migrations, etc.)

None

### Updated (Classes, Methods, Models, etc.)

create_hifu graphql mutation

### Technical Debt Added (What is not being tested? what does this PR break?)

Only tests happy path since we're assuming data will come in as a string of 10 numeric characters.

### Notes

After conversation with Megan this morning, I'm assuming FE form limits users from entering anything other than numbers -- e.g. no white space or extra characters like "-", "(", or ")."

If this functionality changes, we'll need a new issue / PR to create a more complex regex solution.
