### PR TITLE
Checkin

### DIFF
--- a/app/graphql/mutations/check_in.rb
+++ b/app/graphql/mutations/check_in.rb
@@ -1,0 +1,6 @@
+module Mutations
+  class Mutations::CheckIn < Mutations::BaseMutation
+    argument :userEmail, String, required: true
+
+  end
+end

--- a/app/graphql/mutations/check_in.rb
+++ b/app/graphql/mutations/check_in.rb
@@ -2,5 +2,11 @@ module Mutations
   class Mutations::CheckIn < Mutations::BaseMutation
     argument :userEmail, String, required: true
 
+    field :user, Types::UserType, null: false
+    def resolve(userEmail:)
+       user = User.find_by(email: userEmail)
+       user.destroy
+      {user: user}
+    end
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,8 +1,7 @@
 module Types
   class MutationType < Types::BaseObject
     field :create_hifu, mutation: Mutations::CreateHifu
-    # field :create_user, mutation: Mutations::CreateUser
-    # field :create_route, mutation: Mutations::CreateRoute
+    field :check_in, mutation: Mutations::CheckIn
 
   end
 end

--- a/spec/graphql/types/mutation_type_spec.rb
+++ b/spec/graphql/types/mutation_type_spec.rb
@@ -5,7 +5,16 @@ RSpec.describe Types::MutationType do
     User.destroy_all
   end
 
-  describe 'route mutations' do
+  describe 'checkin mutation' do
+    it 'can checkin' do
+      expected_user = build(:user_route_contact)
+      waypoints = build_list(:waypoint, 3)
+      binding.pry
+    end
+    
+  end
+
+  describe 'hifu mutations' do
     it 'can create user contact route waypoints in one endpoint' do
 
       expected_user = build(:user_route_contact)

--- a/spec/graphql/types/mutation_type_spec.rb
+++ b/spec/graphql/types/mutation_type_spec.rb
@@ -7,11 +7,39 @@ RSpec.describe Types::MutationType do
 
   describe 'checkin mutation' do
     it 'can checkin' do
-      expected_user = build(:user_route_contact)
-      waypoints = build_list(:waypoint, 3)
-      binding.pry
+      user = build(:user_route_contact)
+      create(:waypoint, route: user.route)
+      3.times do
+        create(:waypoint, route_id: user.route.id, previous_id: user.route.waypoints.last.id)
+      end
+      
+      query = <<~QL
+      mutation{
+        checkIn(
+          userEmail: "#{user.email}"
+        ){
+          user{
+            name
+            email
+          }
+        }
+      }
+      QL
+
+      expect(User.all.count).to eq(1)
+      expect(Route.all.count).to eq(1)
+      expect(Waypoint.all.count).to eq(4)
+
+
+      ql_response = HifuApiSchema.execute(query)
+      ql_user = ql_response.to_h["data"]["checkIn"]["user"]
+      
+      expect(Route.all.count).to eq(0)
+      expect(Waypoint.all.count).to eq(0)
+      expect(User.all.count).to eq(0)
+      expect(ql_user["name"]).to eq(user.name)
+      expect(ql_user["email"]).to eq(user.email)
     end
-    
   end
 
   describe 'hifu mutations' do


### PR DESCRIPTION
# Check In Mutation

#### Closes: #62 

- [x] All test passing, Test percentage: 99%
- [x] Runs in local dev environment
- [x] PR Documented, Ready for Review

## Type of change made

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test

### What's this PR do? (Detailed Description)

  Add a mutation `checkIn` that accepts a user email as an argument and then removes the matching record from the app.  All user, contact, route, and waypoints associated with that hifu is removed.

### Created (Classes, Methods, Migrations, etc.)

- Migration: `checkIn`
   - Arguments: 
      - userEmail: String
   - Returned types
      - user: the user record that has been removed

### Updated (Classes, Methods, Models, etc.)


### Technical Debt Added (What is not being tested? what does this PR break?)

- Does not handle users with multiple routes.  Currently all routes will be deleted when a user checks in

### Notes
